### PR TITLE
Just get the itunes data once

### DIFF
--- a/MissingArt/ContentView.swift
+++ b/MissingArt/ContentView.swift
@@ -9,19 +9,19 @@ import MissingArtwork
 import SwiftUI
 
 struct ContentView: View {
-  let missingArtworks: [MissingArtwork]
+  let model: Model
 
   var body: some View {
-    DescriptionList(missingArtworks: missingArtworks)
+    DescriptionList(missingArtworks: model.missingArtworks)
   }
 }
 
 struct ContentView_Previews: PreviewProvider {
   static var previews: some View {
-    let missingArtworks = [
+    let model = Model(missingArtworks: [
       MissingArtwork.ArtistAlbum("The Stooges", "Fun House"),
       .CompilationAlbum("Beleza Tropical: Brazil Classics 1"),
-    ]
-    ContentView(missingArtworks: missingArtworks)
+    ])
+    ContentView(model: model)
   }
 }

--- a/MissingArt/MissingArtApp.swift
+++ b/MissingArt/MissingArtApp.swift
@@ -10,16 +10,11 @@ import SwiftUI
 
 @main
 struct MissingArtApp: App {
-  var missingArtworks: [MissingArtwork] {
-    do {
-      return Array(Set<MissingArtwork>(try MissingArtwork.gatherMissingArtwork()))
-    } catch {
-      return []
-    }
-  }
+  private var model = Model()
+
   var body: some Scene {
     WindowGroup {
-      ContentView(missingArtworks: missingArtworks)
+      ContentView(missingArtworks: model.missingArtworks)
     }
   }
 }

--- a/MissingArt/MissingArtApp.swift
+++ b/MissingArt/MissingArtApp.swift
@@ -10,11 +10,11 @@ import SwiftUI
 
 @main
 struct MissingArtApp: App {
-  private var model = Model()
+  private let model = Model()
 
   var body: some Scene {
     WindowGroup {
-      ContentView(missingArtworks: model.missingArtworks)
+      ContentView(model: model)
     }
   }
 }


### PR DESCRIPTION
use an object created once to load the iTunes data. this was noticeable with future work when the SwiftUI View had bindings, and this loaded often.