### PR TITLE
Add NSAppleMusicUsageDescription to Info.plist

### DIFF
--- a/MissingArt.xcodeproj/project.pbxproj
+++ b/MissingArt.xcodeproj/project.pbxproj
@@ -302,6 +302,7 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSAppleMusicUsageDescription = "Missing Artwork uses Apple Music to find artwork images.";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -329,6 +330,7 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSAppleMusicUsageDescription = "Missing Artwork uses Apple Music to find artwork images.";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
- This is required for the app to be able to use MusicKit in the itunes_missing_artwork module.