### PR TITLE
remove file access entitlement

### DIFF
--- a/MissingArt/MissingArt.entitlements
+++ b/MissingArt/MissingArt.entitlements
@@ -4,8 +4,6 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
-	<key>com.apple.security.files.user-selected.read-only</key>
-	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
 </dict>


### PR DESCRIPTION
- after removing picking a .p8 file for the Music API version, this is no longer necessary.