### PR TITLE
Run the applescript in process

### DIFF
--- a/MissingArt.xcodeproj/project.pbxproj
+++ b/MissingArt.xcodeproj/project.pbxproj
@@ -288,6 +288,7 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSAppleEventsUsageDescription = "Missing Artwork uses AppleEvents to fix artwork images.";
 				INFOPLIST_KEY_NSAppleMusicUsageDescription = "Missing Artwork uses Apple Music to find artwork images.";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -316,6 +317,7 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSAppleEventsUsageDescription = "Missing Artwork uses AppleEvents to fix artwork images.";
 				INFOPLIST_KEY_NSAppleMusicUsageDescription = "Missing Artwork uses Apple Music to find artwork images.";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/MissingArt/MissingArt.entitlements
+++ b/MissingArt/MissingArt.entitlements
@@ -4,7 +4,11 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.automation.apple-events</key>
+	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>com.apple.security.temporary-exception.apple-events</key>
+	<string>com.apple.Music</string>
 </dict>
 </plist>

--- a/MissingArt/MissingArtApp.swift
+++ b/MissingArt/MissingArtApp.swift
@@ -52,7 +52,7 @@ struct FixArtError: LocalizedError {
   let message: String
 
   init(nsDictionary: NSDictionary) {
-    let message = nsDictionary["NSAppleScriptErrorMessage"] as? String
+    let message = nsDictionary[NSAppleScript.errorMessage] as? String
     if let message = message {
       self.message = message
     } else {


### PR DESCRIPTION
- Need to change app sandbox entitlements to do this successfully.
- Add some error handling UI.
- Add as an option to the context menu, so Apple Script can still be tested in the Apple Script Editor.