### PR TITLE
Allow errors to be thrown when running AppleScript in process

### DIFF
--- a/MissingArt/MissingArtApp.swift
+++ b/MissingArt/MissingArtApp.swift
@@ -15,7 +15,8 @@ struct MissingArtApp: App {
 
   private func copyPartialArtButton(_ missingArtwork: MissingArtwork) -> some View {
     Button("Copy Partial Art AppleScript") {
-      let appleScript = MissingArtwork.partialArtworksAppleScript([missingArtwork])
+      let appleScript = MissingArtwork.partialArtworksAppleScript(
+        [missingArtwork], catchAndLogErrors: true)
       let pasteboard = NSPasteboard.general
       pasteboard.clearContents()
       pasteboard.setString(appleScript, forType: .string)
@@ -24,7 +25,8 @@ struct MissingArtApp: App {
 
   private func copyArtButton(_ missingArtwork: MissingArtwork, image: NSImage) -> some View {
     Button("Copy Art AppleScript") {
-      let appleScript = MissingArtwork.artworksAppleScript([missingArtwork])
+      let appleScript = MissingArtwork.artworksAppleScript(
+        [missingArtwork], catchAndLogErrors: true)
       let pasteboard = NSPasteboard.general
       pasteboard.clearContents()
       // Put the image on the clipboard for the script. Needs to be first.
@@ -38,7 +40,8 @@ struct MissingArtApp: App {
   }
 
   private func fixPartialArtwork(_ missingArtwork: MissingArtwork) throws {
-    let exec = NSAppleScript(source: MissingArtwork.partialArtworksAppleScript([missingArtwork]))
+    let exec = NSAppleScript(
+      source: MissingArtwork.partialArtworksAppleScript([missingArtwork], catchAndLogErrors: false))
     if let exec = exec {
       var errorDictionary: NSDictionary?
       _ = exec.executeAndReturnError(&errorDictionary)
@@ -98,7 +101,8 @@ struct MissingArtApp: App {
         default:
           let partials = missingImages.filter { $0.availability == .some }.map { $0.missingArtwork }
           Button("Copy Multiple Partial Art AppleScript") {
-            let appleScript = MissingArtwork.partialArtworksAppleScript(partials)
+            let appleScript = MissingArtwork.partialArtworksAppleScript(
+              partials, catchAndLogErrors: true)
 
             let pasteboard = NSPasteboard.general
             pasteboard.clearContents()

--- a/MissingArt/MissingArtwork+AppleScript.swift
+++ b/MissingArt/MissingArtwork+AppleScript.swift
@@ -165,22 +165,32 @@ extension MissingArtwork {
     """
 
   private static func _artworksAppleScript(
-    _ missingArtworks: [MissingArtwork], caller: ((MissingArtwork) -> String)
+    _ missingArtworks: [MissingArtwork],
+    catchAndLogErrors: Bool,
+    caller: ((MissingArtwork) -> String)
   ) -> String {
     var appleScript = """
       \(appleScriptFixAlbumArtFunctionDefinition)
 
       """
     for missingArtwork in missingArtworks {
-      appleScript.append(
-        """
-        try
-          \(caller(missingArtwork))
-        on error errorString
-          log \"Error Trying to Fix Artwork: \" & errorString
-        end try
+      if catchAndLogErrors {
+        appleScript.append(
+          """
+          try
+            \(caller(missingArtwork))
+          on error errorString
+            log \"Error Trying to Fix Artwork: \" & errorString
+          end try
 
-        """)
+          """)
+      } else {
+        appleScript.append(
+          """
+            \(caller(missingArtwork))
+
+          """)
+      }
     }
     appleScript.append(
       """
@@ -189,14 +199,20 @@ extension MissingArtwork {
     return appleScript
   }
 
-  public static func partialArtworksAppleScript(_ missingArtworks: [MissingArtwork]) -> String {
-    return _artworksAppleScript(missingArtworks) { missingArtwork in
+  public static func partialArtworksAppleScript(
+    _ missingArtworks: [MissingArtwork], catchAndLogErrors: Bool
+  ) -> String {
+    return _artworksAppleScript(missingArtworks, catchAndLogErrors: catchAndLogErrors) {
+      missingArtwork in
       missingArtwork.appleScriptCodeToFixPartialArtworkCall
     }
   }
 
-  public static func artworksAppleScript(_ missingArtworks: [MissingArtwork]) -> String {
-    return _artworksAppleScript(missingArtworks) { missingArtwork in
+  public static func artworksAppleScript(
+    _ missingArtworks: [MissingArtwork], catchAndLogErrors: Bool
+  ) -> String {
+    return _artworksAppleScript(missingArtworks, catchAndLogErrors: catchAndLogErrors) {
+      missingArtwork in
       missingArtwork.appleScriptCodeToFixArtworkCall
     }
   }


### PR DESCRIPTION
- Broken by a01ebfa90047f4521906652957f806e530df0454
- When copy / pasting the AppleScript text, catch and logs errors for convenience
- When running the AppleScript in-process via NSAppleScript, do not catch the error and log. Let the native code find the error.