### PR TITLE
Add AppleScript actor

### DIFF
--- a/MissingArt.xcodeproj/project.pbxproj
+++ b/MissingArt.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		FE57696F294509200041E18D /* MissingArtwork+AppleScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE57696E294509200041E18D /* MissingArtwork+AppleScript.swift */; };
+		FE57697629494EA40041E18D /* AppleScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE57697529494EA40041E18D /* AppleScript.swift */; };
 		FE6D2C4F27FF54670056FA7E /* MissingArtApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE6D2C4E27FF54670056FA7E /* MissingArtApp.swift */; };
 		FE6D2C5327FF54680056FA7E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FE6D2C5227FF54680056FA7E /* Assets.xcassets */; };
 		FE6D2C5627FF54680056FA7E /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FE6D2C5527FF54680056FA7E /* Preview Assets.xcassets */; };
@@ -16,6 +17,7 @@
 
 /* Begin PBXFileReference section */
 		FE57696E294509200041E18D /* MissingArtwork+AppleScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MissingArtwork+AppleScript.swift"; sourceTree = "<group>"; };
+		FE57697529494EA40041E18D /* AppleScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleScript.swift; sourceTree = "<group>"; };
 		FE6D2C4B27FF54670056FA7E /* MissingArt.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MissingArt.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		FE6D2C4E27FF54670056FA7E /* MissingArtApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissingArtApp.swift; sourceTree = "<group>"; };
 		FE6D2C5227FF54680056FA7E /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -57,6 +59,7 @@
 			children = (
 				FE6D2C4E27FF54670056FA7E /* MissingArtApp.swift */,
 				FE57696E294509200041E18D /* MissingArtwork+AppleScript.swift */,
+				FE57697529494EA40041E18D /* AppleScript.swift */,
 				FE6D2C5227FF54680056FA7E /* Assets.xcassets */,
 				FE6D2C5727FF54680056FA7E /* MissingArt.entitlements */,
 				FE6D2C5427FF54680056FA7E /* Preview Content */,
@@ -157,6 +160,7 @@
 			files = (
 				FE57696F294509200041E18D /* MissingArtwork+AppleScript.swift in Sources */,
 				FE6D2C4F27FF54670056FA7E /* MissingArtApp.swift in Sources */,
+				FE57697629494EA40041E18D /* AppleScript.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MissingArt/AppleScript.swift
+++ b/MissingArt/AppleScript.swift
@@ -1,0 +1,74 @@
+//
+//  AppleScript.swift
+//  MissingArt
+//
+//  Created by Greg Bolsinga on 12/13/22.
+//
+
+import Foundation
+
+private enum AppleScriptError: Error {
+  case cannotInitialize
+  case cannotCompile(String)
+  case unknownCompileError
+  case cannotExecute(String)
+  case unknownExecuteError
+}
+
+extension AppleScriptError {
+  fileprivate static func createCompileError(_ nsDictionary: NSDictionary) -> AppleScriptError {
+    if let message = nsDictionary[NSAppleScript.errorMessage] as? String {
+      return .cannotCompile(message)
+    }
+    return .unknownCompileError
+  }
+
+  fileprivate static func createExecuteError(_ nsDictionary: NSDictionary) -> AppleScriptError {
+    if let message = nsDictionary[NSAppleScript.errorMessage] as? String {
+      return .cannotExecute(message)
+    }
+    return .unknownExecuteError
+  }
+}
+
+extension AppleScriptError: LocalizedError {
+  var errorDescription: String? {
+    switch self {
+    case .cannotInitialize:
+      return "AppleScript Initialization Error"
+    case .cannotCompile(let message):
+      return "AppleScript Compilation Error: \(message)"
+    case .unknownCompileError:
+      return "Unknown AppleScript Compilation Error"
+    case .cannotExecute(let message):
+      return "AppleScript Execution Error: \(message)"
+    case .unknownExecuteError:
+      return "Unknown AppleScript Execution Error"
+    }
+  }
+}
+
+public actor AppleScript {
+  private var script: NSAppleScript
+
+  public init(source: String) throws {
+    let exec = NSAppleScript(source: source)
+    guard let exec = exec else { throw AppleScriptError.cannotInitialize }
+
+    var errorDictionary: NSDictionary?
+    _ = exec.compileAndReturnError(&errorDictionary)
+    if let errorDictionary = errorDictionary {
+      throw AppleScriptError.createCompileError(errorDictionary)
+    } else {
+      script = exec
+    }
+  }
+
+  public func run() throws {
+    var errorDictionary: NSDictionary?
+    _ = script.executeAndReturnError(&errorDictionary)
+    if let errorDictionary = errorDictionary {
+      throw AppleScriptError.createExecuteError(errorDictionary)
+    }
+  }
+}

--- a/MissingArt/MissingArtApp.swift
+++ b/MissingArt/MissingArtApp.swift
@@ -65,7 +65,7 @@ struct MissingArtApp: App {
     Button("Fix Partial Art") {
       Task {
         do {
-          try MissingArtwork.fixPartialArtwork(missingArtwork)
+          try await MissingArtwork.fixPartialArtwork(missingArtwork)
         } catch let error as LocalizedError {
           await reportError(FixArtError.cannotFixPartialArtwork(missingArtwork, error))
         } catch {


### PR DESCRIPTION
- This separates running AppleScript and its errors from the artwork.
- This sets us up to compile the script once, and then pass multiple native parameters to it.