### PR TITLE
Run AppleScript on non-main again

### DIFF
--- a/MissingArt/MissingArtApp.swift
+++ b/MissingArt/MissingArtApp.swift
@@ -30,6 +30,13 @@ extension FixArtError: LocalizedError {
   }
 }
 
+private extension MissingArtwork {
+  func fixPartialArtwork() async throws {
+    let script = try AppleScript(source: MissingArtwork.partialArtworksAppleScript([self], catchAndLogErrors: false))
+    try await script.run()
+  }
+}
+
 @main
 struct MissingArtApp: App {
 
@@ -84,10 +91,7 @@ struct MissingArtApp: App {
               Button("Fix Partial Art") {
                 Task {
                   do {
-                    let script = try AppleScript(
-                      source: MissingArtwork.partialArtworksAppleScript(
-                        [missingImage.missingArtwork], catchAndLogErrors: false))
-                    try await script.run()
+                    try await missingImage.missingArtwork.fixPartialArtwork()
                   } catch let error as LocalizedError {
                     reportError(
                       FixArtError.cannotFixPartialArtwork(missingImage.missingArtwork, error))


### PR DESCRIPTION
- Broken by 72dbc4f735f6c03be770d35fc30e0ef08e71f864
- Calling a func annotated with async will "throw" this off onto another thread than main.