### PR TITLE
Compile AppleScript and call it natively with parameters.

### DIFF
--- a/MissingArt/MissingArtApp.swift
+++ b/MissingArt/MissingArtApp.swift
@@ -30,14 +30,6 @@ extension FixArtError: LocalizedError {
   }
 }
 
-extension MissingArtwork {
-  fileprivate func fixPartialArtwork() async throws {
-    let script = try AppleScript(
-      source: MissingArtwork.partialArtworksAppleScript([self], catchAndLogErrors: false))
-    try await script.run()
-  }
-}
-
 @main
 struct MissingArtApp: App {
 

--- a/MissingArt/MissingArtwork+AppleScript.swift
+++ b/MissingArt/MissingArtwork+AppleScript.swift
@@ -190,3 +190,14 @@ extension MissingArtwork {
     }
   }
 }
+
+extension MissingArtwork {
+  func fixPartialArtwork() async throws {
+    let script = try AppleScript(source: MissingArtwork.appleScriptFixAlbumArtFunctionDefinition)
+
+    let params = appleScriptFixPartialArtworkParameters
+    try await script.run(
+      handler: params.0,
+      parameters: params.1, params.2, params.3, params.4)
+  }
+}


### PR DESCRIPTION
- This still re-compiles the script each time.
- Use variadic Any to see if they can be converted to NSAppleEventDescriptor via a AppleScriptDescriptable protocol. -- only two types (String and Bool) are supported now; easy to add more in the future if needed.