### PR TITLE
Pass image data to AppleScript handler

### DIFF
--- a/MissingArt/MissingArtApp.swift
+++ b/MissingArt/MissingArtApp.swift
@@ -89,7 +89,6 @@ struct MissingArtApp: App {
                     addToPasteboard(string: appleScript, image: image)
                   }
                   Button("Fix Art") {
-                    addToPasteboard(image: image)
                     Task {
                       updateProcessingState(
                         missingImage.missingArtwork, processingState: .processing)
@@ -97,7 +96,8 @@ struct MissingArtApp: App {
                       var result: Bool = false
                       do {
                         if let script = script {
-                          result = try await script.fixArtwork(missingImage.missingArtwork)
+                          result = try await script.fixArtwork(
+                            missingImage.missingArtwork, image: image)
                         }
                       } catch let error as LocalizedError {
                         reportError(

--- a/MissingArt/MissingArtwork+AppleScript.swift
+++ b/MissingArt/MissingArtwork+AppleScript.swift
@@ -5,6 +5,7 @@
 //  Created by Greg Bolsinga on 12/10/22.
 //
 
+import AppKit
 import Foundation
 import MissingArtwork
 
@@ -32,7 +33,7 @@ extension MissingArtwork {
     -> String
   {
     return """
-          \(parameters.0)(\"\(parameters.1)\", \"\(parameters.2)\", \"\(parameters.3)\", \(parameters.4))
+          \(parameters.0)(\"\(parameters.1)\", \"\(parameters.2)\", \"\(parameters.3)\", \(parameters.4), missing value)
       """
   }
 
@@ -90,7 +91,7 @@ extension MissingArtwork {
       end tell
       return matches
     end verifyTrack
-    on fixAlbumArtwork(searchString, albumString, artistString, findImageInTracks)
+    on fixAlbumArtwork(searchString, albumString, artistString, findImageInTracks, externalImageData)
       tell application "Music"
         global findImageHandler
         set findImageHandler to missing value
@@ -110,7 +111,12 @@ extension MissingArtwork {
             set the end of results to trk
           end if
         end repeat
-        set imageData to my findImageHandler(results)
+        set imageData to missing value
+        if externalImageData is not missing value then
+          set imageData to externalImageData
+        else
+          set imageData to my findImageHandler(results)
+        end if
         if imageData is missing value then
           set message to "Cannot find image data for " & searchString
           error message number 502
@@ -206,8 +212,9 @@ extension AppleScript {
       parameters: params.1, params.2, params.3, params.4)
   }
 
-  func fixArtwork(_ missingArtwork: MissingArtwork) async throws -> Bool {
+  func fixArtwork(_ missingArtwork: MissingArtwork, image: NSImage) async throws -> Bool {
     let params = missingArtwork.appleScriptFixArtworkParameters
-    return try self.run(handler: params.0, parameters: params.1, params.2, params.3, params.4)
+    return try self.run(
+      handler: params.0, parameters: params.1, params.2, params.3, params.4, image)
   }
 }


### PR DESCRIPTION
- Examined an image data return value in the debugger to figure out what the descriptorType should be for the data.
- update the AppleScript handler to take the image data parameter and then call a method only if it is not missing value.
- pass missing value for the image data for the textual Apple Script output