### PR TITLE
Remove Disabling In-App AppleScript

### DIFF
--- a/MissingArt/MissingArtApp.swift
+++ b/MissingArt/MissingArtApp.swift
@@ -125,7 +125,7 @@ struct MissingArtApp: App {
                           missingImage.missingArtwork, image: image)
                       }
                     }
-                  }.disabled(script == nil)
+                  }
                 } else {
                   Text("No Image Selected")
                 }
@@ -145,7 +145,7 @@ struct MissingArtApp: App {
                       return try await script.fixPartialArtwork(missingImage.missingArtwork)
                     }
                   }
-                }.disabled(script == nil)
+                }
               case .unknown:
                 Text("Unknown Artwork Issue")
               }


### PR DESCRIPTION
Despite being @State script != nil is not refreshing these. I wonder if it isn't that this is a imageMenuContextBuilder, and if SwiftUI does not "see" the change in state. Need to investigate later.