### PR TITLE
Fix in-app Partial Artwork Fixing

### DIFF
--- a/MissingArt/AppleScript.swift
+++ b/MissingArt/AppleScript.swift
@@ -147,6 +147,7 @@ public actor AppleScript {
     var errorDictionary: NSDictionary?
     let result = script.executeAppleEvent(event, error: &errorDictionary)
     if let errorDictionary {
+      debugPrint("Apple Script Error : \(errorDictionary)")
       throw AppleScriptError.createExecuteAppleEventError(errorDictionary)
     }
     return result.booleanValue

--- a/MissingArt/MissingArtwork+AppleScript.swift
+++ b/MissingArt/MissingArtwork+AppleScript.swift
@@ -37,18 +37,14 @@ extension MissingArtwork {
       """
   }
 
-  private var fixAlbumArtworkHandler: String {
-    "fixAlbumArtwork"
-  }
-
   fileprivate var appleScriptFixPartialArtworkParameters: (String, String, String, String, Bool) {
     let params = appleScriptVerificationParameters
-    return (fixAlbumArtworkHandler, appleScriptSearchRepresentation, params.0, params.1, true)
+    return ("fixAlbumArtworkPartial", appleScriptSearchRepresentation, params.0, params.1, true)
   }
 
   fileprivate var appleScriptFixArtworkParameters: (String, String, String, String, Bool) {
     let params = appleScriptVerificationParameters
-    return (fixAlbumArtworkHandler, appleScriptSearchRepresentation, params.0, params.1, false)
+    return ("fixAlbumArtwork", appleScriptSearchRepresentation, params.0, params.1, false)
   }
 
   private var appleScriptCodeToFixPartialArtworkCall: String {
@@ -91,6 +87,9 @@ extension MissingArtwork {
       end tell
       return matches
     end verifyTrack
+    on fixAlbumArtworkPartial(searchString, albumString, artistString, findImageInTracks)
+      fixAlbumArtwork(searchString, albumString, artistString, findImageInTracks, missing value)
+    end fixAlbumArtworkPartial
     on fixAlbumArtwork(searchString, albumString, artistString, findImageInTracks, externalImageData)
       tell application "Music"
         global findImageHandler


### PR DESCRIPTION
- somehow i didn't test this after refactoring!
- Expected a "missing value" to appear, but it did not.
- Could not quickly figure out how to create one from the native side, so instead just made an AppleScript helper handler to fix partial art.
- dump the full AppleScript errorDictionary to the console when debugging.