### PR TITLE
Use separated context menu builders for no and partial artwork

### DIFF
--- a/MissingArt/Resources/en.lproj/Localizable.strings
+++ b/MissingArt/Resources/en.lproj/Localizable.strings
@@ -4,29 +4,14 @@
 /* Error message when AppleScript cannot be initialized by the application. */
 "AppleScript Initialization Error: %@" = "AppleScript Initialization Error: %@";
 
-/* Menu Action to copy AppleScript to fix album artwork for albums with no artwork. */
-"Copy Art AppleScript" = "Copy Art AppleScript";
-
 /* Menu Action to copy the selected album image. */
 "Copy Artwork Image" = "Copy Artwork Image";
 
-/* Menu Action to copy AppleScript to fix multiple album's artwork for albums with some artwork. */
-"Copy Multiple Partial Art AppleScript" = "Copy Multiple Partial Art AppleScript";
+/* Menu Action to copy AppleScript to fix album artwork. */
+"Copy Fix Art AppleScript" = "Copy Fix Art AppleScript";
 
-/* Menu Action to copy AppleScript to fix album artwork for albums with some artwork. */
-"Copy Partial Art AppleScript" = "Copy Partial Art AppleScript";
-
-/* Menu Action to fix album artwork when there is no artwork. */
+/* Menu Action to fix album artwork in process. */
 "Fix Art" = "Fix Art";
-
-/* Menu Action to fix album artwork when there is some artwork. */
-"Fix Partial Art" = "Fix Partial Art";
-
-/* Text shown when no image is selected and the user selects the option to fix the artwork for an album with none. */
-"No Image Selected" = "No Image Selected";
-
-/* Shown when context menu has nothing to do. */
-"Nothing To Do" = "Nothing To Do";
 
 /* OK button for alert shown when there is an unrecoverable error. */
 "OK" = "OK";
@@ -36,7 +21,4 @@
 
 /* Error message when missing artwork cannot be fixed. */
 "Unable to change Music artwork image for %@: %@" = "Unable to change Music artwork image for %@: %@";
-
-/* Text shown when user selects the option to fix artwork for an album with an unknown issue. */
-"Unknown Artwork Issue" = "Unknown Artwork Issue";
 


### PR DESCRIPTION
- simplify the text around these actions too.
- only show copy image if one no-artwork is selected.
- only show copy applescript when there is one no-artwork selected.