### PR TITLE
Simplify AppleScript handling

### DIFF
--- a/MissingArt/AppleScript.swift
+++ b/MissingArt/AppleScript.swift
@@ -105,7 +105,7 @@ extension AppleScriptError: LocalizedError {
   }
 }
 
-public actor AppleScript {
+public struct AppleScript {
   private var script: NSAppleScript
 
   public init(source: String) throws {
@@ -119,15 +119,6 @@ public actor AppleScript {
     } else {
       script = exec
     }
-  }
-
-  public func run() throws -> Bool {
-    var errorDictionary: NSDictionary?
-    let result = script.executeAndReturnError(&errorDictionary)
-    if let errorDictionary {
-      throw AppleScriptError.createExecuteError(errorDictionary)
-    }
-    return result.booleanValue
   }
 
   private func run(handler: String, parameters: NSAppleEventDescriptor) throws -> Bool {

--- a/MissingArt/MissingArtApp.swift
+++ b/MissingArt/MissingArtApp.swift
@@ -28,29 +28,29 @@ struct MissingArtApp: App {
     return loadingState.currentError
   }
 
-  @MainActor private func reportError(_ error: FixArtError) {
+  private func reportError(_ error: FixArtError) {
     fixArtError = error
   }
 
-  @MainActor private func updateProcessingState(
+  private func updateProcessingState(
     _ missingArtwork: MissingArtwork, processingState: ProcessingState
   ) {
     processingStates[missingArtwork] = processingState
   }
 
   private func fixArtworkAppleScript(
-    missingArtwork: MissingArtwork, scriptHandler: () async throws -> Bool
-  ) async {
-    await updateProcessingState(missingArtwork, processingState: .processing)
+    missingArtwork: MissingArtwork, scriptHandler: () throws -> Bool
+  ) {
+    updateProcessingState(missingArtwork, processingState: .processing)
 
     var result: Bool = false
     do {
-      result = try await scriptHandler()
+      result = try scriptHandler()
     } catch {
-      await reportError(FixArtError.cannotFixArtwork(missingArtwork, error))
+      reportError(FixArtError.cannotFixArtwork(missingArtwork, error))
     }
 
-    await updateProcessingState(missingArtwork, processingState: result ? .success : .failure)
+    updateProcessingState(missingArtwork, processingState: result ? .success : .failure)
   }
 
   @ViewBuilder private var copyAppleScriptLabel: some View {
@@ -118,8 +118,8 @@ struct MissingArtApp: App {
               }
 
               for missingImage in missingImages {
-                await fixArtworkAppleScript(missingArtwork: missingImage.missingArtwork) {
-                  return try await script.fixArtwork(
+                fixArtworkAppleScript(missingArtwork: missingImage.missingArtwork) {
+                  return try script.fixArtwork(
                     missingImage.missingArtwork, image: missingImage.image)
                 }
               }
@@ -143,8 +143,8 @@ struct MissingArtApp: App {
                 return
               }
               for missingArtwork in missingArtworks {
-                await fixArtworkAppleScript(missingArtwork: missingArtwork) {
-                  return try await script.fixPartialArtwork(missingArtwork)
+                fixArtworkAppleScript(missingArtwork: missingArtwork) {
+                  return try script.fixPartialArtwork(missingArtwork)
                 }
               }
             }

--- a/MissingArt/MissingArtwork+AppleScript.swift
+++ b/MissingArt/MissingArtwork+AppleScript.swift
@@ -190,14 +190,14 @@ extension MissingArtwork {
 }
 
 extension AppleScript {
-  func fixPartialArtwork(_ missingArtwork: MissingArtwork) async throws -> Bool {
+  func fixPartialArtwork(_ missingArtwork: MissingArtwork) throws -> Bool {
     let params = missingArtwork.appleScriptFixPartialArtworkParameters
     return try self.run(
       handler: params.0,
       parameters: params.1, params.2, params.3, params.4)
   }
 
-  func fixArtwork(_ missingArtwork: MissingArtwork, image: NSImage) async throws -> Bool {
+  func fixArtwork(_ missingArtwork: MissingArtwork, image: NSImage) throws -> Bool {
     let params = missingArtwork.appleScriptFixArtworkParameters
     return try self.run(
       handler: params.0, parameters: params.1, params.2, params.3, params.4, image)


### PR DESCRIPTION
- It had to be on the main thread back when it was a `executeAndRun`. This is no longer the case
- It's in a `Task`, so it does not block the main thread.